### PR TITLE
Added cognito support

### DIFF
--- a/application-loadbalancer.cfhighlander.rb
+++ b/application-loadbalancer.cfhighlander.rb
@@ -2,6 +2,7 @@ CfhighlanderTemplate do
 
   # Name 'application-loadbalancer'
   DependsOn 'lib-ec2'
+  DependsOn 'lib-alb'
 
   Parameters do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true
@@ -11,6 +12,9 @@ CfhighlanderTemplate do
     ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'
     ComponentParam 'SslCertId', ''
     ComponentParam 'WebACLArn', ''
+    ComponentParam 'UserPoolId', ''
+    ComponentParam 'UserPoolClientId', ''
+    ComponentParam 'UserPoolDomainName', ''
     
     if use_zone_id == true
       ComponentParam 'HostedZoneId', ''

--- a/application-loadbalancer.cfndsl.rb
+++ b/application-loadbalancer.cfndsl.rb
@@ -92,7 +92,7 @@ CloudFormation do
     default_actions = rule_actions(listener['default']['action'])
     
     default_actions_with_cognito = rule_actions(listener['default']['action'])
-    default_actions_with_cognito << cognito(self)
+    default_actions_with_cognito << cognito(Ref(:UserPoolId),Ref(:UserPoolClientId),Ref(:UserPoolDomainName))
 
     ElasticLoadBalancingV2_Listener("#{listener_name}Listener") do
       Protocol listener['protocol'].upcase
@@ -139,7 +139,7 @@ CloudFormation do
       actions = rule_actions(rule['actions'])
 
       actions_with_cognito = rule_actions(rule['actions'])
-      actions_with_cognito << cognito(self)
+      actions_with_cognito << cognito(Ref(:UserPoolId),Ref(:UserPoolClientId),Ref(:UserPoolDomainName))
 
       ElasticLoadBalancingV2_ListenerRule(rule_name) do
         Actions FnIf(:EnableCognito, actions_with_cognito, actions)

--- a/application-loadbalancer.cfndsl.rb
+++ b/application-loadbalancer.cfndsl.rb
@@ -94,14 +94,14 @@ CloudFormation do
     default_actions_with_cognito = rule_actions(listener['default']['action'])
     default_actions_with_cognito << cognito(Ref(:UserPoolId),Ref(:UserPoolClientId),Ref(:UserPoolDomainName))
 
-    Condition(:ListenerIsHTTPS, FnEquals(listener['protocol'].upcase, 'HTTPS'))
+    Condition("#{listener_name}isHTTPS", FnEquals(listener['protocol'].upcase, 'HTTPS'))
 
     ElasticLoadBalancingV2_Listener("#{listener_name}Listener") do
       Protocol listener['protocol'].upcase
       Certificates [{ CertificateArn: Ref('SslCertId') }] if listener['protocol'].upcase == 'HTTPS'
       SslPolicy listener['ssl_policy'] if listener.has_key?('ssl_policy')
       Port listener['port']
-      DefaultActions FnIf(:EnableCognito, FnIf(:ListenerIsHTTPS, default_actions_with_cognito, default_actions), default_actions)
+      DefaultActions FnIf(:EnableCognito, FnIf("#{listener_name}isHTTPS", default_actions_with_cognito, default_actions), default_actions)
       LoadBalancerArn Ref(:LoadBalancer)
     end
 
@@ -144,7 +144,7 @@ CloudFormation do
       actions_with_cognito << cognito(Ref(:UserPoolId),Ref(:UserPoolClientId),Ref(:UserPoolDomainName))
 
       ElasticLoadBalancingV2_ListenerRule(rule_name) do
-        Actions FnIf(:EnableCognito, FnIf(:ListenerIsHTTPS, actions_with_cognito, actions), actions)
+        Actions FnIf(:EnableCognito, FnIf("#{listener_name}isHTTPS", actions_with_cognito, actions), actions)
         Conditions rule_conditions(rule['conditions'])
         ListenerArn Ref("#{listener_name}Listener")
         Priority rule['priority']


### PR DESCRIPTION
Added cognito support to ALB component.

Cognito is enabled by provisioning the `cognitio` component and adding the parameter `cognito:true` to the load balancer HTTPS Listener.

HTTPS Listener Example 
```
listeners:
  https:
    port: 443
    protocol: https
    cognito: true
    #ssl_policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
    default:
      action:
        targetgroup: default
```

An demo highlander repo and be found [here](https://github.com/base2Services/demo-alb-cognitio-auth)